### PR TITLE
Rel demo 30.06.26 CSI-5475

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -3,7 +3,7 @@ HOST: https://api.ehealth.gov.ua
 
 # GENERAL MIS API
 
-**Version: 9.15.0 v.1**
+**Version: 9.15.9 v.1**
 
 Environment: **DEMO**
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -9336,6 +9336,30 @@ If medical program has funding sourse NHS, fields `sell_amount`, `sell_price`, `
             + type: MOBILE (string, required) - `Dictionary PHONE_TYPE` type of phone Land Line or Mobile. At least one of type must be present. Each type can be represented only once.
             + number: +38093*****85 (string, required) - confidant person phone number, masked
 
+### `Confidant_Person_Relationship_Full_Masked`
++ id: `b075f148-7f93-4fc2-b2ec-2d81b19a9b7b` (string, required) - confidant person relationship identifier
++ active_to: `2025-08-19` (string, optional) - the date when confidant person relationship is active to
++ `documents_relationship` (array[`RelationshipDocument_with_record_type`], required)
++ `relationship_verification_details` (object, required)
+    + `verification_status`: `VERIFICATION_NEEDED` (string, required) - status of relationship verification according to `PERSONS_RELATIONSHIP_VERIFICATION_STATUSES` dictionary
+    + `verification_reason`: `MANUAL_CREATED_BY_DOCTOR` (string, required) - how current relationship verification status has been set according to `PERSONS_RELATIONSHIP_VERIFICATION_STATUSES` dictionary
+    + `verification_comment`: `Підтверджено на підставі свідоцтва про народження` (string, optional) - Relationship verification status description set by NHS or Doctor
++ confidant_person (object, required)
+    + person_id: `b075f148-7f93-4fc2-b2ec-2d81b19a9b7b` (string, required) - confidant person identifier
+    + name: Петров А.А. (string, required) - confidant person name, masked
+    + gender: MALE, FEMALE (enum[string], optional)
+    + tax_id: ******50 (string, optional) - confidant person tax id, masked
+    + no_tax_id: false (boolean, required) - fact of declining tax_id
+    + unzr: `**********99` (string, optional) - unzr (if exists), masked
+    + documents_person (array)
+        + (object)
+            + type: PASSPORT (string, required) - `Dictionary DOCUMENT_TYPE`
+            + number: ******18 (string, required) - confidant person document issue number, masked
+    + phones (array)
+        + (object)
+            + type: MOBILE (string, required) - `Dictionary PHONE_TYPE` type of phone Land Line or Mobile. At least one of type must be present. Each type can be represented only once.
+            + number: +38093*****85 (string, required) - confidant person phone number, masked
+
 ### `Create_Confidant_Person_request`
 + confidant_person_id: `7b100a9c-daaa-490e-b88d-2a911059b055` (string, required) - identifier of person who will become confidant
 + documents_relationship (array, required)
@@ -10535,6 +10559,7 @@ status: `APPROVED` (string, required)
 + emergency_contact (object, required)
     + include `Emergency_Contact`
 + `confidant_person` (array[`Confidant_Person`], optional) - Should be set if this Person is disabled, underage, etc.
++ `confidant_person_relationship` (array[`Confidant_Person_Relationship_Full_Masked`], optional) - Should be set if this Person has active confidant person relationships
 + unzr: `20090705-00011` (string, optional) - the record number in the demographic register
 + preferred_way_communication: email (enum, optional) - the way how a patient wants to be reached
     - email
@@ -11679,6 +11704,14 @@ status: `APPROVED` (string, required)
 + issued_at: `2017-02-28` (string, required) - the date when document was issued
 + active_to: `2025-08-19` (string, optional) - the date then period of document validity ends.
 
+### `RelationshipDocument_with_record_type`
++ type: BIRTH_CERTIFICATE (string, required) - `Dictionary DOCUMENT_RELATIONSHIP_TYPE`
++ number: АА120518 (string, required) - document issue number
++ issued_by: `Рокитнянським РВ ГУ МВС Київської області` (string, required) - authority which issued the document
++ issued_at: `2017-02-28` (string, required) - the date when document was issued
++ active_to: `2025-08-19` (string, optional) - the date then period of document validity ends
++ `record_type`: `relationship_confirmation` (string, required) - `Dictionary DOCUMENT_RELATIONSHIP_RECORD_TYPE`
+
 ### `Medical_Certificate`
 + name: Диплом доктора медицини (string, required)
 + number: AA1234BC (string, required)
@@ -12046,7 +12079,7 @@ status: `APPROVED` (string, required)
 + city: Київ (string, required)
 + institution_name: Академія Богомольця (string, required)
 + issued_date: `2017-02-28` (string, optional)
-+ diploma_number: DD123543 (string, required)
++ diploma_number: DD123543 (string, optional)
 + degree: MASTER (string, required) - `Dictionary EDUCATION_DEGREE`
 + speciality: Педіатр (string, required)
 


### PR DESCRIPTION
Ported from ehealth-ua/mis-api-gen#8, which was opened against the wrong repo — General MIS's actual upstream is `api-spec`, not `mis-api-gen`. Same file diff (`apiary.apib`, +34/-1), unchanged content.

https://e-health-ua.atlassian.net/browse/CSI-5475

## Summary
- Adds `Confidant_Person_Relationship_Full_Masked` and `RelationshipDocument_with_record_type` data structures.
- Wires `confidant_person_relationship` (array, optional) onto the v2 personal-data response.
- Makes `diploma_number` optional (was required).

🤖 Generated with [Claude Code](https://claude.com/claude-code)